### PR TITLE
Update CPI-ABS.csv

### DIFF
--- a/Data/CPI-ABS.csv
+++ b/Data/CPI-ABS.csv
@@ -43,5 +43,8 @@
 "Dec-24","0.2","2.4"
 "Mar-25","0.9","2.4"
 "Jun-25","0.7","2.1"
+"Sep-25","1.3","3.6"
+"Dec-25","0.6","3.8"
+"Mar-26","1.4","4.6"
 
 "Source: Australian Bureau of Statistics, Consumer Price Index, Australia June Quarter 2025"


### PR DESCRIPTION
Updated CPI-ABS.csv to have latest inflation figures up to March 2026. Maintained quarterly inflation instead of moving to monthly which ABS has done